### PR TITLE
Fix ambulance body map section becoming unresponsive

### DIFF
--- a/lib/ambulance/ambulance.dart
+++ b/lib/ambulance/ambulance.dart
@@ -59,6 +59,8 @@ class _AmbulancePageState extends State<AmbulancePage> {
 
   @override
   Widget build(BuildContext context) {
+    final bool isBodyMapSection = _currentSectionIndex == 5;
+
     return Scaffold(
       backgroundColor: bgLight,
       body: SafeArea(
@@ -77,7 +79,7 @@ class _AmbulancePageState extends State<AmbulancePage> {
 
             // 2. 中間內容區域
             Expanded(
-              child: SingleChildScrollView(
+              child: Padding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 24,
                   vertical: 32,
@@ -86,7 +88,9 @@ class _AmbulancePageState extends State<AmbulancePage> {
                   duration: const Duration(milliseconds: 250),
                   child: Container(
                     key: ValueKey(_currentSectionIndex),
-                    child: _getCurrentPage(),
+                    child: isBodyMapSection
+                        ? _getCurrentPage()
+                        : SingleChildScrollView(child: _getCurrentPage()),
                   ),
                 ),
               ),


### PR DESCRIPTION
### Motivation
- The Body Map page uses an interactive `Stack`/`LayoutBuilder`/`InteractiveViewer` that requires bounded vertical constraints, and wrapping it in a vertical `SingleChildScrollView` can provide unbounded height and cause the UI to become unresponsive or crash.

### Description
- Update `lib/ambulance/ambulance.dart` to add an `isBodyMapSection` check and only wrap non-body-map sections with `SingleChildScrollView`, while rendering the Body Map section directly to preserve bounded layout and interactive behavior.

### Testing
- Attempted to run `dart format lib/ambulance/ambulance.dart`, but the environment returned a missing `dart` executable so formatting could not be executed. 
- Attempted to run `flutter --version`, but `flutter` is not available in PATH so no runtime build/test was executed. 
- Performed static inspection of the modified file to verify the conditional wrapping logic and that other sections keep their scroll behavior, with no other files modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03c3f376c832b80cf3e3b8f9538f8)